### PR TITLE
Fix security improvement

### DIFF
--- a/compassion/functions.php
+++ b/compassion/functions.php
@@ -796,7 +796,31 @@ add_filter('pre_http_request', function ($preempt, $parsed_args, $url) {
 }, 10, 3);
 
 // Disable the pingback functionality, which is often used as a vector for DDoS attacks or spam.
-add_filter('xmlrpc_methods', function ($methods) {
+add_filter('xmlrpc_methods', function($methods) {
   unset($methods['pingback.ping']);
   return $methods;
 });
+
+// Block user enumeration
+if (!is_admin()) {
+	// Check if the query string contains "author" with a number value
+	if (preg_match('/author=([0-9]*)/i', $_SERVER['QUERY_STRING'])) {
+		// Terminate the script execution if the query string matches the pattern
+		die();
+	}
+	
+	// Add a filter to modify the redirect URL
+	add_filter('redirect_canonical', 'shapeSpace_check_enum', 10, 2);
+}
+
+// Check and modify redirect URL
+function shapeSpace_check_enum($redirect, $request) {
+	// Check if the requested URL contains "author" with a number value
+	if (preg_match('/\?author=([0-9]*)(\/*)/i', $request)) {
+		// Terminate the script execution if the requested URL matches the pattern
+		die();
+	} else {
+		// Return the initial redirect URL if the requested URL doesn't match the pattern
+		return $redirect;
+	}
+}

--- a/compassion/functions.php
+++ b/compassion/functions.php
@@ -794,3 +794,9 @@ add_filter('pre_http_request', function ($preempt, $parsed_args, $url) {
 
     return $preempt;
 }, 10, 3);
+
+// Disable the pingback functionality, which is often used as a vector for DDoS attacks or spam.
+add_filter('xmlrpc_methods', function ($methods) {
+  unset($methods['pingback.ping']);
+  return $methods;
+});


### PR DESCRIPTION
Related issue: [CP-373](https://compassion-ch.atlassian.net/browse/CP-373)

WordPress is affected by an unauthenticated blind SSRF in the pingback feature from XML-RPC. This could lead to spam/DDOS attack, it is recommended to disable the pingback feature if not used.
https://blog.sonarsource.com/wordpress-core-unauthenticated-blind-ssrf/ 

In WordPress, user can be enumerated through the archive functionality, it is recommended to disable user enumeration if not used as this could lead to successful brute force attacks.

[CP-373]: https://compassion-ch.atlassian.net/browse/CP-373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ